### PR TITLE
Reorganize work client config

### DIFF
--- a/py_swf/__init__.py
+++ b/py_swf/__init__.py
@@ -4,4 +4,4 @@ from __future__ import unicode_literals
 
 __author__ = 'Henri Bai'
 __email__ = 'hbai@yelp.com'
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/py_swf/__init__.py
+++ b/py_swf/__init__.py
@@ -4,4 +4,4 @@ from __future__ import unicode_literals
 
 __author__ = 'Henri Bai'
 __email__ = 'hbai@yelp.com'
-__version__ = '1.3.1'
+__version__ = '1.4.0'

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -12,6 +12,8 @@ CountWorkflowsResult = namedtuple(
 )
 """
 An immutable object that stores results of counting workflows.
+Wrapper around response from :meth:`~SWF.Client.count_closed_workflow_executions and
+:meth:`~SWF.Client.count_open_workflow_executions.
 count (integer) -- The number of workflow executions.
 truncated (boolean) -- If set to true, indicates that the actual count was more than the maximum supported by this API
     and the count returned is the truncated value.

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -2,10 +2,20 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from py_swf.config_definitions import StartWorkflowResult
-from py_swf.config_definitions import CountWorkflowsResult
+from collections import namedtuple
 
 __all__ = ['WorkflowClient']
+
+CountWorkflowsResult = namedtuple(
+    'CountWorkflowsResult',
+    'count truncated',
+)
+"""
+An immutable object that stores results of counting workflows.
+count (integer) -- The number of workflow executions.
+truncated (boolean) -- If set to true, indicates that the actual count was more than the maximum supported by this API
+    and the count returned is the truncated value.
+"""
 
 
 class WorkflowClient(object):
@@ -38,24 +48,21 @@ class WorkflowClient(object):
         :returns: An AWS generated uuid that represents a unique identifier for the run of this workflow.
         :rtype: string
         """
-        start_workflow_result = StartWorkflowResult(
-            run_id=self.boto_client.start_workflow_execution(
-                domain=self.workflow_client_config.domain,
-                childPolicy='TERMINATE',
-                workflowId=id,
-                input=input,
-                workflowType={
-                    'name': workflow_name,
-                    'version': version,
-                },
-                taskList={
-                    'name': self.workflow_client_config.task_list,
-                },
-                executionStartToCloseTimeout=str(self.workflow_client_config.execution_start_to_close_timeout),
-                taskStartToCloseTimeout=str(self.workflow_client_config.task_start_to_close_timeout),
-            )['runId']
-        )
-        return start_workflow_result.run_id
+        return self.boto_client.start_workflow_execution(
+            domain=self.workflow_client_config.domain,
+            childPolicy='TERMINATE',
+            workflowId=id,
+            input=input,
+            workflowType={
+                'name': workflow_name,
+                'version': version,
+            },
+            taskList={
+                'name': self.workflow_client_config.task_list,
+            },
+            executionStartToCloseTimeout=str(self.workflow_client_config.execution_start_to_close_timeout),
+            taskStartToCloseTimeout=str(self.workflow_client_config.task_start_to_close_timeout),
+        )['runId']
 
     def terminate_workflow(self, workflow_id, reason):
         """Forcefully terminates a workflow by preventing further responding and executions of
@@ -115,14 +122,12 @@ class WorkflowClient(object):
             latest_start_date=latest_start_date,
         )
 
-        count_open_workflows_result = CountWorkflowsResult(
-            **self.boto_client.count_open_workflow_executions(
-                domain=self.workflow_client_config.domain,
-                startTimeFilter=start_time_filter_dict['startTimeFilter'],
-                **workflow_filter_dict
-            )
+        response = self.boto_client.count_open_workflow_executions(
+            domain=self.workflow_client_config.domain,
+            startTimeFilter=start_time_filter_dict['startTimeFilter'],
+            **workflow_filter_dict
         )
-        return count_open_workflows_result.count
+        return CountWorkflowsResult(count=response['count'], truncated=response['truncated'])
 
     def count_closed_workflow_executions(
             self,
@@ -177,13 +182,11 @@ class WorkflowClient(object):
         )
         workflow_filter_dict.update(time_filter_dict)
 
-        count_closed_workflows_result = CountWorkflowsResult(
-            **self.boto_client.count_closed_workflow_executions(
-                domain=self.workflow_client_config.domain,
-                **workflow_filter_dict
-            )
+        response = self.boto_client.count_closed_workflow_executions(
+            domain=self.workflow_client_config.domain,
+            **workflow_filter_dict
         )
-        return count_closed_workflows_result.count
+        return CountWorkflowsResult(count=response['count'], truncated=response['truncated'])
 
 
 def _build_time_filter_dict(oldest_start_date=None, latest_start_date=None, oldest_close_date=None, latest_close_date=None):

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -18,7 +18,7 @@ class WorkflowClient(object):
         self.workflow_client_config = workflow_client_config
         self.boto_client = boto_client
 
-    def start_workflow(self, input, id):
+    def start_workflow(self, input, id, workflow_name, version):
         """Enqueues and starts a workflow to SWF.
 
         Passthrough to :meth:`~SWF.Client.start_workflow_execution`.
@@ -27,6 +27,11 @@ class WorkflowClient(object):
         :type input: string
         :param id: Freeform string that represents a unique identifier for the workflow.
         :type id: string
+        :param workflow_name: The name of the workflow type. The combination of workflow type name and version must be
+            unique with in a domain.
+        :type workflow_name: string
+        :param version: The version of the workflow type.
+        :type version: string
         :returns: An AWS generated uuid that represents a unique identifier for the run of this workflow.
         :rtype: string
         """
@@ -36,8 +41,8 @@ class WorkflowClient(object):
             workflowId=id,
             input=input,
             workflowType={
-                'name': self.workflow_client_config.workflow_name,
-                'version': self.workflow_client_config.workflow_version,
+                'name': workflow_name,
+                'version': version,
             },
             taskList={
                 'name': self.workflow_client_config.task_list,

--- a/py_swf/config_definitions.py
+++ b/py_swf/config_definitions.py
@@ -12,22 +12,6 @@ WorkflowClientConfig = namedtuple(
 """An immutable object that stores common SWF values. Used by instances of :class:`~py_swf.clients.workflow.WorkflowClient`.
 """
 
-StartWorkflowResult = namedtuple(
-    'StartWorkflowResult',
-    'run_id'
-)
-"""
-An immutable object that stores response after calling start_workflow_execution.
-Used by instances of :class:`~py_swf.clients.workflow.WorkflowClient`.
-"""
-
-CountWorkflowsResult = namedtuple(
-    'CountWorkflowsResult',
-    'count truncated',
-)
-"""An immutable object that stores results of counting workflows. Used by instances of :class:`~py_swf.clients.WorkflowClient`.
-"""
-
 DecisionConfig = namedtuple(
     'DecisionConfig',
     'domain task_list schedule_to_close_timeout schedule_to_start_timeout start_to_close_timeout heartbeat_timeout',

--- a/py_swf/config_definitions.py
+++ b/py_swf/config_definitions.py
@@ -12,6 +12,22 @@ WorkflowClientConfig = namedtuple(
 """An immutable object that stores common SWF values. Used by instances of :class:`~py_swf.clients.workflow.WorkflowClient`.
 """
 
+StartWorkflowResult = namedtuple(
+    'StartWorkflowResult',
+    'run_id'
+)
+"""
+An immutable object that stores response after calling start_workflow_execution.
+Used by instances of :class:`~py_swf.clients.workflow.WorkflowClient`.
+"""
+
+CountWorkflowsResult = namedtuple(
+    'CountWorkflowsResult',
+    'count truncated',
+)
+"""An immutable object that stores results of counting workflows. Used by instances of :class:`~py_swf.clients.WorkflowClient`.
+"""
+
 DecisionConfig = namedtuple(
     'DecisionConfig',
     'domain task_list schedule_to_close_timeout schedule_to_start_timeout start_to_close_timeout heartbeat_timeout',

--- a/py_swf/config_definitions.py
+++ b/py_swf/config_definitions.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 WorkflowClientConfig = namedtuple(
     'WorkflowClientConfig',
-    'domain workflow_name workflow_version task_list execution_start_to_close_timeout task_start_to_close_timeout',
+    'domain task_list execution_start_to_close_timeout task_start_to_close_timeout',
 )
 """An immutable object that stores common SWF values. Used by instances of :class:`~py_swf.clients.workflow.WorkflowClient`.
 """

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -103,8 +103,6 @@ def workflow_client(boto_client, domain_name, task_list, workflow_name, version,
     workflow_client_config = WorkflowClientConfig(
         domain=domain_name,
         task_list=task_list,
-        workflow_name=workflow_name,
-        workflow_version=version,
         execution_start_to_close_timeout=5,
         task_start_to_close_timeout=5,
     )

--- a/tests/acceptance/workflow_test.py
+++ b/tests/acceptance/workflow_test.py
@@ -25,6 +25,8 @@ def start_workflow(workflow_client, workflow_id):
             meow='yes',
         )),
         id=workflow_id,
+        workflow_name='test',
+        version='0.1'
     )
 
 

--- a/tests/unit/clients/workflow_test.py
+++ b/tests/unit/clients/workflow_test.py
@@ -134,10 +134,11 @@ class TestCountOpenWorkflowExecutions:
             mocked_boto_client,
             oldest_start_date
     ):
-        count = workflow_client.count_open_workflow_executions(
+        response = workflow_client.count_open_workflow_executions(
             oldest_start_date=oldest_start_date,
-        ).count
-        assert count == 123
+        )
+        assert response.count == 123
+        assert not response.truncated
         mocked_boto_client.count_open_workflow_executions.assert_called_with(
             domain=workflow_config.domain,
             startTimeFilter=dict(oldestDate=oldest_start_date),
@@ -241,8 +242,9 @@ class TestCountClosedWorkflowExecutions:
             mocked_boto_client,
             oldest_start_date,
     ):
-        count = workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date).count
-        assert count == 321
+        response = workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date)
+        assert response.count == 321
+        assert response.truncated
         mocked_boto_client.count_closed_workflow_executions.assert_called_with(
             domain=workflow_config.domain,
             startTimeFilter=dict(oldestDate=oldest_start_date)

--- a/tests/unit/clients/workflow_test.py
+++ b/tests/unit/clients/workflow_test.py
@@ -17,25 +17,8 @@ def workflow_config():
 
 
 @pytest.fixture
-def mocked_boto_client():
-    mocked_boto_client = mock.Mock()
-    mocked_boto_client.count_open_workflow_executions.return_value = {
-        'count': 123,
-        'truncated': False
-    }
-    mocked_boto_client.count_closed_workflow_executions.return_value = {
-        'count': 321,
-        'truncated': True
-    }
-    mocked_boto_client.start_workflow_execution.return_value = {
-        'runId': 233
-    }
-    return mocked_boto_client
-
-
-@pytest.fixture
-def workflow_client(workflow_config, mocked_boto_client):
-    return WorkflowClient(workflow_config, mocked_boto_client)
+def workflow_client(workflow_config, boto_client):
+    return WorkflowClient(workflow_config, boto_client)
 
 
 @pytest.fixture
@@ -58,9 +41,9 @@ def latest_close_date():
     return datetime(2016, 11, 29)
 
 
-def test_start_workflow(workflow_config, workflow_client, mocked_boto_client):
+def test_start_workflow(workflow_config, workflow_client, boto_client):
     boto_return = mock.MagicMock()
-    mocked_boto_client.start_workflow_execution.return_value = boto_return
+    boto_client.start_workflow_execution.return_value = boto_return
     workflow_name = 'test'
     version = '0.1'
     actual_run_id = workflow_client.start_workflow(
@@ -70,7 +53,7 @@ def test_start_workflow(workflow_config, workflow_client, mocked_boto_client):
         version=version,
     )
 
-    mocked_boto_client.start_workflow_execution.assert_called_once_with(
+    boto_client.start_workflow_execution.assert_called_once_with(
         domain=workflow_config.domain,
         childPolicy='TERMINATE',
         workflowId='cat',
@@ -88,12 +71,12 @@ def test_start_workflow(workflow_config, workflow_client, mocked_boto_client):
     assert actual_run_id == boto_return['runId']
 
 
-def test_terminate_workflow(workflow_config, workflow_client, mocked_boto_client):
+def test_terminate_workflow(workflow_config, workflow_client, boto_client):
     workflow_client.terminate_workflow(
         'workflow_id',
         'reason',
     )
-    mocked_boto_client.terminate_workflow_execution.assert_called_once_with(
+    boto_client.terminate_workflow_execution.assert_called_once_with(
         domain=workflow_config.domain,
         workflowId='workflow_id',
         reason='reason',
@@ -129,294 +112,326 @@ def test_build_time_filter_dict_with_close_date_range(oldest_close_date, latest_
     assert time_filter_dict['closeTimeFilter'] == {'oldestDate': oldest_close_date, 'latestDate': latest_close_date}
 
 
-def test_count_open_workflow_executions_with_oldest_start_time(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date
-):
-    count = workflow_client.count_open_workflow_executions(
-        oldest_start_date=oldest_start_date,
-    ).count
-    assert count == 123
-    mocked_boto_client.count_open_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-    )
+class TestCountOpenWorkflowExecutions:
 
+    @pytest.fixture
+    def mocked_boto_client(self):
+        mocked_boto_client = mock.Mock()
+        mocked_boto_client.count_open_workflow_executions.return_value = {
+            'count': 123,
+            'truncated': False
+        }
+        return mocked_boto_client
 
-def test_count_open_workflow_executions_with_start_time_range(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-        latest_start_date
-):
-    workflow_client.count_open_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        latest_start_date=latest_start_date,
-    )
-    mocked_boto_client.count_open_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(
-            oldestDate=oldest_start_date,
-            latestDate=latest_start_date,
-        ),
-    )
+    @pytest.fixture
+    def workflow_client(self, workflow_config, mocked_boto_client):
+        return WorkflowClient(workflow_config, mocked_boto_client)
 
+    def test_count_open_workflow_executions_with_oldest_start_time(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date
+    ):
+        count = workflow_client.count_open_workflow_executions(
+            oldest_start_date=oldest_start_date,
+        ).count
+        assert count == 123
+        mocked_boto_client.count_open_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+        )
 
-def test_count_open_workflow_executions_with_oldest_start_time_and_workflow_name(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_open_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        workflow_name='test',
-        version='test',
-    )
-    mocked_boto_client.count_open_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        typeFilter=dict(
-            name='test',
+    def test_count_open_workflow_executions_with_start_time_range(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+            latest_start_date
+    ):
+        workflow_client.count_open_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            latest_start_date=latest_start_date,
+        )
+        mocked_boto_client.count_open_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(
+                oldestDate=oldest_start_date,
+                latestDate=latest_start_date,
+            ),
+        )
+
+    def test_count_open_workflow_executions_with_oldest_start_time_and_workflow_name(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_open_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            workflow_name='test',
             version='test',
         )
-    )
-
-
-def test_count_open_workflow_executions_with_oldest_start_time_and_tag(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_open_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        tag='test',
-    )
-    mocked_boto_client.count_open_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        tagFilter=dict(tag='test'),
-    )
-
-
-def test_count_open_workflow_executions_with_oldest_start_time_and_workflow_id(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_open_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        workflow_id='test'
-    )
-    mocked_boto_client.count_open_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        executionFilter=dict(workflowId='test'),
-    )
-
-
-def test_count_closed_workflow_executions_and_oldest_start_time(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    count = workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date).count
-    assert count == 321
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date)
-    )
-
-
-def test_count_closed_workflow_executions_with_start_time_range(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-        latest_start_date,
-):
-    workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date, latest_start_date=latest_start_date)
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(
-            oldestDate=oldest_start_date,
-            latestDate=latest_start_date,
+        mocked_boto_client.count_open_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            typeFilter=dict(
+                name='test',
+                version='test',
+            )
         )
-    )
+
+    def test_count_open_workflow_executions_with_oldest_start_time_and_tag(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_open_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            tag='test',
+        )
+        mocked_boto_client.count_open_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            tagFilter=dict(tag='test'),
+        )
+
+    def test_count_open_workflow_executions_with_oldest_start_time_and_workflow_id(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_open_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            workflow_id='test'
+        )
+        mocked_boto_client.count_open_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            executionFilter=dict(workflowId='test'),
+        )
 
 
-def test_count_closed_workflow_executions_with_oldest_close_time(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(oldest_close_date=oldest_close_date)
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date),
-    )
+class TestCountClosedWorkflowExecutions:
 
+    @pytest.fixture
+    def mocked_boto_client(self):
+        mocked_boto_client = mock.Mock()
+        mocked_boto_client.count_closed_workflow_executions.return_value = {
+            'count': 321,
+            'truncated': True
+        }
+        return mocked_boto_client
 
-def test_count_closed_workflow_executions_with_close_time_range(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-        latest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(oldest_close_date=oldest_close_date, latest_close_date=latest_close_date)
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date, latestDate=latest_close_date),
-    )
+    @pytest.fixture
+    def workflow_client(self, workflow_config, mocked_boto_client):
+        return WorkflowClient(workflow_config, mocked_boto_client)
 
+    def test_count_closed_workflow_executions_and_oldest_start_time(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        count = workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date).count
+        assert count == 321
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date)
+        )
 
-def test_count_closed_workflow_executions_with_oldest_start_time_and_workflow_name(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        workflow_name='test',
-        version='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        typeFilter=dict(
-            name='test',
+    def test_count_closed_workflow_executions_with_start_time_range(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+            latest_start_date,
+    ):
+        workflow_client.count_closed_workflow_executions(oldest_start_date=oldest_start_date, latest_start_date=latest_start_date)
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(
+                oldestDate=oldest_start_date,
+                latestDate=latest_start_date,
+            )
+        )
+
+    def test_count_closed_workflow_executions_with_oldest_close_time(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(oldest_close_date=oldest_close_date)
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date),
+        )
+
+    def test_count_closed_workflow_executions_with_close_time_range(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+            latest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(oldest_close_date=oldest_close_date, latest_close_date=latest_close_date)
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date, latestDate=latest_close_date),
+        )
+
+    def test_count_closed_workflow_executions_with_oldest_start_time_and_workflow_name(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            workflow_name='test',
             version='test',
-        ),
-    )
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            typeFilter=dict(
+                name='test',
+                version='test',
+            ),
+        )
 
-
-def test_count_closed_workflow_executions_with_oldest_close_time_and_workflow_name(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_close_date=oldest_close_date,
-        workflow_name='test',
-        version='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date),
-        typeFilter=dict(
-            name='test',
+    def test_count_closed_workflow_executions_with_oldest_close_time_and_workflow_name(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_close_date=oldest_close_date,
+            workflow_name='test',
             version='test',
-        ),
-    )
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date),
+            typeFilter=dict(
+                name='test',
+                version='test',
+            ),
+        )
 
+    def test_count_closed_workflow_executions_with_oldest_start_time_and_tag(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            tag='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            tagFilter=dict(tag='test'),
+        )
 
-def test_count_closed_workflow_executions_with_oldest_start_time_and_tag(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        tag='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        tagFilter=dict(tag='test'),
-    )
+    def test_count_closed_workflow_executions_with_oldest_close_time_and_tag(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_close_date=oldest_close_date,
+            tag='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date),
+            tagFilter=dict(tag='test'),
+        )
 
+    def test_count_closed_workflow_executions_with_oldest_start_time_and_workflow_id(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            workflow_id='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            executionFilter=dict(workflowId='test'),
+        )
 
-def test_count_closed_workflow_executions_with_oldest_close_time_and_tag(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_close_date=oldest_close_date,
-        tag='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date),
-        tagFilter=dict(tag='test'),
-    )
+    def test_count_closed_workflow_executions_with_oldest_close_time_and_workflow_id(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_close_date=oldest_close_date,
+            workflow_id='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date),
+            executionFilter=dict(workflowId='test'),
+        )
 
+    def test_count_closed_workflow_executions_with_oldest_start_time_and_close_status(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_start_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_start_date=oldest_start_date,
+            close_status='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            startTimeFilter=dict(oldestDate=oldest_start_date),
+            closeStatusFilter=dict(status='test'),
+        )
 
-def test_count_closed_workflow_executions_with_oldest_start_time_and_workflow_id(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        workflow_id='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        executionFilter=dict(workflowId='test'),
-    )
-
-
-def test_count_closed_workflow_executions_with_oldest_close_time_and_workflow_id(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_close_date=oldest_close_date,
-        workflow_id='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date),
-        executionFilter=dict(workflowId='test'),
-    )
-
-
-def test_count_closed_workflow_executions_with_oldest_start_time_and_close_status(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_start_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_start_date=oldest_start_date,
-        close_status='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        startTimeFilter=dict(oldestDate=oldest_start_date),
-        closeStatusFilter=dict(status='test'),
-    )
-
-
-def test_count_closed_workflow_executions_with_oldest_close_time_and_close_status(
-        workflow_config,
-        workflow_client,
-        mocked_boto_client,
-        oldest_close_date,
-):
-    workflow_client.count_closed_workflow_executions(
-        oldest_close_date=oldest_close_date,
-        close_status='test',
-    )
-    mocked_boto_client.count_closed_workflow_executions.assert_called_with(
-        domain=workflow_config.domain,
-        closeTimeFilter=dict(oldestDate=oldest_close_date),
-        closeStatusFilter=dict(status='test'),
-    )
+    def test_count_closed_workflow_executions_with_oldest_close_time_and_close_status(
+            self,
+            workflow_config,
+            workflow_client,
+            mocked_boto_client,
+            oldest_close_date,
+    ):
+        workflow_client.count_closed_workflow_executions(
+            oldest_close_date=oldest_close_date,
+            close_status='test',
+        )
+        mocked_boto_client.count_closed_workflow_executions.assert_called_with(
+            domain=workflow_config.domain,
+            closeTimeFilter=dict(oldestDate=oldest_close_date),
+            closeStatusFilter=dict(status='test'),
+        )

--- a/tests/unit/clients/workflow_test.py
+++ b/tests/unit/clients/workflow_test.py
@@ -44,9 +44,13 @@ def latest_close_date():
 def test_start_workflow(workflow_config, workflow_client, boto_client):
     boto_return = mock.MagicMock()
     boto_client.start_workflow_execution.return_value = boto_return
+    workflow_name = 'test'
+    version = '0.1'
     actual_run_id = workflow_client.start_workflow(
         input='meow',
         id='cat',
+        workflow_name=workflow_name,
+        version=version,
     )
 
     boto_client.start_workflow_execution.assert_called_once_with(
@@ -55,8 +59,8 @@ def test_start_workflow(workflow_config, workflow_client, boto_client):
         workflowId='cat',
         input='meow',
         workflowType={
-            'name': workflow_config.workflow_name,
-            'version': workflow_config.workflow_version,
+            'name': workflow_name,
+            'version': version,
         },
         taskList={
             'name': workflow_config.task_list,

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps = pre-commit>=0.4.2
 commands = pre-commit {posargs}
 
 [testenv:docs]
+basepython=/usr/bin/python2.7
 deps =
     {[testenv]deps}
     sphinx


### PR DESCRIPTION
Move workflow_name and version out of WorkflowClientConfig, since they are not necessary for terminate workflow or count workflow. Make them necessary args for start_workflow.
Specify basepython version to be python2.7 to avoid 'tox -e docs' failure.