### PR TITLE
Support specify timeout for workflow and activity

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "tests/unit/clients/decision_test.py::test_finish_decision_with_activity": true
+}

--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "tests/unit/clients/decision_test.py::test_finish_decision_with_activity": true
-}

--- a/py_swf/__init__.py
+++ b/py_swf/__init__.py
@@ -4,4 +4,4 @@ from __future__ import unicode_literals
 
 __author__ = 'Henri Bai'
 __email__ = 'hbai@yelp.com'
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/py_swf/clients/decision.py
+++ b/py_swf/clients/decision.py
@@ -157,7 +157,8 @@ class DecisionClient(object):
 
             kwargs['nextPageToken'] = next_page_token
 
-    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input, override_config_dict=None):
+    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input,
+                                      override_config_dict=None):
         """Responds to a given decision task's task_token to schedule an activity task to run.
 
         Passthrough to :meth:`~SWF.Client.respond_decision_task_completed`.
@@ -172,6 +173,10 @@ class DecisionClient(object):
         :type identity: string
         :param activity_input: Freeform text of the input for the activity
         :type identity: string
+        :param override_config_dict: Override default config for scheduled activity timeouts.
+        It includes scheduleToCloseTimeout, scheduleToStartTimeout and startToCloseTimeout.
+        More info: http://docs.aws.amazon.com/amazonswf/latest/apireference/API_ScheduleActivityTaskDecisionAttributes.html
+        :type identity: dict
         :return: None
         :rtype: NoneType
         """
@@ -219,9 +224,9 @@ def build_workflow_complete(result):
 
 def build_activity_task(activity_id, activity_name, activity_version, input, decision_config, override_config_dict=None):
     override_config_dict = override_config_dict or {}
-    schedule_to_close_timeout = override_config_dict.get('schedule_to_close_timeout', None) or decision_config.schedule_to_close_timeout
-    schedule_to_start_timeout = override_config_dict.get('schedule_to_start_timeout', None) or decision_config.schedule_to_start_timeout
-    start_to_close_timeout = override_config_dict.get('start_to_close_timeout', None) or decision_config.start_to_close_timeout
+    schedule_to_close_timeout = override_config_dict.get('schedule_to_close_timeout', decision_config.schedule_to_close_timeout)
+    schedule_to_start_timeout = override_config_dict.get('schedule_to_start_timeout', decision_config.schedule_to_start_timeout)
+    start_to_close_timeout = override_config_dict.get('start_to_close_timeout', decision_config.start_to_close_timeout)
     return {
         'decisionType': 'ScheduleActivityTask',
         'scheduleActivityTaskDecisionAttributes': {

--- a/py_swf/clients/decision.py
+++ b/py_swf/clients/decision.py
@@ -249,11 +249,11 @@ def build_activity_task(
     start_to_close_timeout,
 ):
     if schedule_to_close_timeout is None:
-        schedule_to_start_timeout = decision_config.schedule_to_close_timeout
+        schedule_to_close_timeout = decision_config.schedule_to_close_timeout
     if schedule_to_start_timeout is None:
-        schedule_to_start_timeout = decision_config.schedule_to_close_timeout
+        schedule_to_start_timeout = decision_config.schedule_to_start_timeout
     if start_to_close_timeout is None:
-        start_to_close_timeout = decision_config.schedule_to_start_timeout
+        start_to_close_timeout = decision_config.start_to_close_timeout
     return {
         'decisionType': 'ScheduleActivityTask',
         'scheduleActivityTaskDecisionAttributes': {

--- a/py_swf/clients/decision.py
+++ b/py_swf/clients/decision.py
@@ -157,7 +157,7 @@ class DecisionClient(object):
 
             kwargs['nextPageToken'] = next_page_token
 
-    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input):
+    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input, override_config_dict):
         """Responds to a given decision task's task_token to schedule an activity task to run.
 
         Passthrough to :meth:`~SWF.Client.respond_decision_task_completed`.
@@ -181,6 +181,7 @@ class DecisionClient(object):
             activity_version,
             activity_input,
             self.decision_config,
+            override_config_dict,
         )
 
         self.boto_client.respond_decision_task_completed(
@@ -216,7 +217,10 @@ def build_workflow_complete(result):
     }
 
 
-def build_activity_task(activity_id, activity_name, activity_version, input, decision_config):
+def build_activity_task(activity_id, activity_name, activity_version, input, decision_config, override_config_dict):
+    schedule_to_close_timeout = override_config_dict.get('schedule_to_close_timeout', None) or decision_config.schedule_to_close_timeout
+    schedule_to_start_timeout = override_config_dict.get('schedule_to_start_timeout', None) or decision_config.schedule_to_start_timeout
+    start_to_close_timeout = override_config_dict.get('start_to_close_timeout', None) or decision_config.start_to_close_timeout
     return {
         'decisionType': 'ScheduleActivityTask',
         'scheduleActivityTaskDecisionAttributes': {
@@ -229,9 +233,9 @@ def build_activity_task(activity_id, activity_name, activity_version, input, dec
             'taskList': {
                 'name': decision_config.task_list,
             },
-            'scheduleToCloseTimeout': str(decision_config.schedule_to_close_timeout),
-            'scheduleToStartTimeout': str(decision_config.schedule_to_start_timeout),
-            'startToCloseTimeout': str(decision_config.start_to_close_timeout),
+            'scheduleToCloseTimeout': str(schedule_to_close_timeout),
+            'scheduleToStartTimeout': str(schedule_to_start_timeout),
+            'startToCloseTimeout': str(start_to_close_timeout),
             'heartbeatTimeout': str(decision_config.heartbeat_timeout),
         },
     }

--- a/py_swf/clients/decision.py
+++ b/py_swf/clients/decision.py
@@ -157,7 +157,7 @@ class DecisionClient(object):
 
             kwargs['nextPageToken'] = next_page_token
 
-    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input, override_config_dict):
+    def finish_decision_with_activity(self, task_token, activity_id, activity_name, activity_version, activity_input, override_config_dict=None):
         """Responds to a given decision task's task_token to schedule an activity task to run.
 
         Passthrough to :meth:`~SWF.Client.respond_decision_task_completed`.
@@ -217,7 +217,8 @@ def build_workflow_complete(result):
     }
 
 
-def build_activity_task(activity_id, activity_name, activity_version, input, decision_config, override_config_dict):
+def build_activity_task(activity_id, activity_name, activity_version, input, decision_config, override_config_dict=None):
+    override_config_dict = override_config_dict or {}
     schedule_to_close_timeout = override_config_dict.get('schedule_to_close_timeout', None) or decision_config.schedule_to_close_timeout
     schedule_to_start_timeout = override_config_dict.get('schedule_to_start_timeout', None) or decision_config.schedule_to_start_timeout
     start_to_close_timeout = override_config_dict.get('start_to_close_timeout', None) or decision_config.start_to_close_timeout

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -33,7 +33,7 @@ class WorkflowClient(object):
         self.workflow_client_config = workflow_client_config
         self.boto_client = boto_client
 
-    def start_workflow(self, input, id, workflow_name, version):
+    def start_workflow(self, input, id, workflow_name, version, workflow_start_to_close_timeout=None):
         """Enqueues and starts a workflow to SWF.
 
         Passthrough to :meth:`~SWF.Client.start_workflow_execution`.
@@ -50,6 +50,7 @@ class WorkflowClient(object):
         :returns: An AWS generated uuid that represents a unique identifier for the run of this workflow.
         :rtype: string
         """
+        execution_start_to_close_timeout = workflow_start_to_close_timeout or self.workflow_client_config.execution_start_to_close_timeout
         return self.boto_client.start_workflow_execution(
             domain=self.workflow_client_config.domain,
             childPolicy='TERMINATE',
@@ -62,7 +63,7 @@ class WorkflowClient(object):
             taskList={
                 'name': self.workflow_client_config.task_list,
             },
-            executionStartToCloseTimeout=str(self.workflow_client_config.execution_start_to_close_timeout),
+            executionStartToCloseTimeout=str(execution_start_to_close_timeout),
             taskStartToCloseTimeout=str(self.workflow_client_config.task_start_to_close_timeout),
         )['runId']
 

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -50,7 +50,8 @@ class WorkflowClient(object):
         :returns: An AWS generated uuid that represents a unique identifier for the run of this workflow.
         :rtype: string
         """
-        execution_start_to_close_timeout = workflow_start_to_close_timeout or self.workflow_client_config.execution_start_to_close_timeout
+        execution_start_to_close_timeout = workflow_start_to_close_timeout or \
+            self.workflow_client_config.execution_start_to_close_timeout
         return self.boto_client.start_workflow_execution(
             domain=self.workflow_client_config.domain,
             childPolicy='TERMINATE',

--- a/py_swf/clients/workflow.py
+++ b/py_swf/clients/workflow.py
@@ -50,8 +50,8 @@ class WorkflowClient(object):
         :returns: An AWS generated uuid that represents a unique identifier for the run of this workflow.
         :rtype: string
         """
-        execution_start_to_close_timeout = workflow_start_to_close_timeout or \
-            self.workflow_client_config.execution_start_to_close_timeout
+        if workflow_start_to_close_timeout is None:
+            workflow_start_to_close_timeout = self.workflow_client_config.execution_start_to_close_timeout
         return self.boto_client.start_workflow_execution(
             domain=self.workflow_client_config.domain,
             childPolicy='TERMINATE',
@@ -64,7 +64,7 @@ class WorkflowClient(object):
             taskList={
                 'name': self.workflow_client_config.task_list,
             },
-            executionStartToCloseTimeout=str(execution_start_to_close_timeout),
+            executionStartToCloseTimeout=str(workflow_start_to_close_timeout),
             taskStartToCloseTimeout=str(self.workflow_client_config.task_start_to_close_timeout),
         )['runId']
 

--- a/tests/acceptance/workflow_test.py
+++ b/tests/acceptance/workflow_test.py
@@ -45,6 +45,7 @@ def poll_decision_and_respond(decision_client, response_override_dict=None):
         activity_name='test_activity',
         activity_version='0.1',
         activity_input=simplejson.dumps(activity_input),
+        override_config_dict=response_override_dict,
     )
     return decision_task
 
@@ -99,7 +100,7 @@ def test_workflow(workflow_client, decision_client, activity_task_client):
 
 def test_workflow_with_start_to_close_timeout(workflow_client, decision_client, activity_task_client):
     workflow_id = str(uuid.uuid4())
-    start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout=10)
+    start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout=60)
     poll_decision_and_respond(decision_client)
     poll_activity_task_and_respond(activity_task_client)
     poll_decision_and_finish_workflow(decision_client, workflow_client)
@@ -107,7 +108,7 @@ def test_workflow_with_start_to_close_timeout(workflow_client, decision_client, 
 
 def test_workflow_with_activity_timeout(workflow_client, decision_client, activity_task_client):
     workflow_id = str(uuid.uuid4())
-    start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout=10)
+    start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout=100)
     override_dict = {
         'schedule_to_close_timeout': 30,
         'schedule_to_start_timeout': 10,

--- a/tests/acceptance/workflow_test.py
+++ b/tests/acceptance/workflow_test.py
@@ -31,7 +31,7 @@ def start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout
     )
 
 
-def poll_decision_and_respond(decision_client, response_override_dict=None):
+def poll_decision_and_respond(decision_client, activity_timeout_config_dict=None):
     decision_task = decision_client.poll()
 
     activity_id = str(uuid.uuid4())
@@ -45,7 +45,7 @@ def poll_decision_and_respond(decision_client, response_override_dict=None):
         activity_name='test_activity',
         activity_version='0.1',
         activity_input=simplejson.dumps(activity_input),
-        override_config_dict=response_override_dict,
+        **activity_timeout_config_dict
     )
     return decision_task
 
@@ -109,12 +109,12 @@ def test_workflow_with_start_to_close_timeout(workflow_client, decision_client, 
 def test_workflow_with_activity_timeout(workflow_client, decision_client, activity_task_client):
     workflow_id = str(uuid.uuid4())
     start_workflow(workflow_client, workflow_id, workflow_start_to_close_timeout=100)
-    override_dict = {
+    activity_timeout_config = {
         'schedule_to_close_timeout': 30,
         'schedule_to_start_timeout': 10,
         'start_to_close_timeout': 20,
     }
-    poll_decision_and_respond(decision_client, response_override_dict=override_dict)
+    poll_decision_and_respond(decision_client, activity_timeout_config_dict=activity_timeout_config)
     poll_activity_task_and_respond(activity_task_client)
     poll_decision_and_finish_workflow(decision_client, workflow_client)
 

--- a/tests/unit/clients/decision_test.py
+++ b/tests/unit/clients/decision_test.py
@@ -213,18 +213,15 @@ class TestPollingWithBadResults:
 
 
 def test_finish_decision_with_activity(decision_client, decision_config, boto_client):
-    override_config_dict = {
-        'schedule_to_close_timeout': 123,
-        'schedule_to_start_timeout': 223,
-        'start_to_close_timeout': 233,
-    }
     decision_client.finish_decision_with_activity(
         'task_token',
         'activity_id',
         'activity_name',
         'activity_version',
         'activity_input',
-        override_config_dict,
+        schedule_to_close_timeout=123,
+        schedule_to_start_timeout=223,
+        start_to_close_timeout=233,
     )
 
     decisions = boto_client.respond_decision_task_completed.call_args[1]['decisions'][0]

--- a/tests/unit/clients/decision_test.py
+++ b/tests/unit/clients/decision_test.py
@@ -213,15 +213,25 @@ class TestPollingWithBadResults:
 
 
 def test_finish_decision_with_activity(decision_client, decision_config, boto_client):
+    override_config_dict = {
+        'schedule_to_close_timeout': 123,
+        'schedule_to_start_timeout': 223,
+        'start_to_close_timeout': 233,
+    }
     decision_client.finish_decision_with_activity(
         'task_token',
         'activity_id',
         'activity_name',
         'activity_version',
         'activity_input',
-        {},
+        override_config_dict,
     )
 
+    decisions = boto_client.respond_decision_task_completed.call_args[1]['decisions'][0]
+    decision_attrs = decisions['scheduleActivityTaskDecisionAttributes']
+    assert decision_attrs['scheduleToCloseTimeout'] == str(123)
+    assert decision_attrs['scheduleToStartTimeout'] == str(223)
+    assert decision_attrs['startToCloseTimeout'] == str(233)
     boto_client.respond_decision_task_completed.assert_called_once_with(
         taskToken='task_token',
         # We rely on acceptence test for the schema of decisions

--- a/tests/unit/clients/decision_test.py
+++ b/tests/unit/clients/decision_test.py
@@ -219,7 +219,7 @@ def test_finish_decision_with_activity(decision_client, decision_config, boto_cl
         'activity_name',
         'activity_version',
         'activity_input',
-        'override_config_dict',
+        {},
     )
 
     boto_client.respond_decision_task_completed.assert_called_once_with(

--- a/tests/unit/clients/decision_test.py
+++ b/tests/unit/clients/decision_test.py
@@ -219,6 +219,7 @@ def test_finish_decision_with_activity(decision_client, decision_config, boto_cl
         'activity_name',
         'activity_version',
         'activity_input',
+        'override_config_dict',
     )
 
     boto_client.respond_decision_task_completed.assert_called_once_with(

--- a/tests/unit/clients/decision_test.py
+++ b/tests/unit/clients/decision_test.py
@@ -224,8 +224,8 @@ def test_finish_decision_with_activity(decision_client, decision_config, boto_cl
         'activity_input',
     )
 
-    decisions = boto_client.respond_decision_task_completed.call_args[1]['decisions'][0]
-    decision_attrs = decisions['scheduleActivityTaskDecisionAttributes']
+    decisions = boto_client.respond_decision_task_completed.call_args[1]['decisions']
+    decision_attrs = decisions[0]['scheduleActivityTaskDecisionAttributes']
     assert decision_attrs['scheduleToCloseTimeout'] == str(decision_config.schedule_to_close_timeout)
     assert decision_attrs['scheduleToStartTimeout'] == str(decision_config.schedule_to_start_timeout)
     assert decision_attrs['startToCloseTimeout'] == str(decision_config.start_to_close_timeout)

--- a/tests/unit/clients/workflow_test.py
+++ b/tests/unit/clients/workflow_test.py
@@ -42,6 +42,7 @@ def latest_close_date():
 
 
 def test_start_workflow(workflow_config, workflow_client, boto_client):
+    workflow_config.execution_start_to_close_timeout = 1
     boto_return = mock.MagicMock()
     boto_client.start_workflow_execution.return_value = boto_return
     workflow_name = 'test'
@@ -69,6 +70,8 @@ def test_start_workflow(workflow_config, workflow_client, boto_client):
         taskStartToCloseTimeout=str(workflow_config.task_start_to_close_timeout),
     )
     assert actual_run_id == boto_return['runId']
+    assert str(workflow_config.execution_start_to_close_timeout) ==\
+        boto_client.start_workflow_execution.call_args[1]['executionStartToCloseTimeout']
 
 
 def test_start_workflow_with_custom_execution_timeout(workflow_config, workflow_client, boto_client):

--- a/tests/unit/clients/workflow_test.py
+++ b/tests/unit/clients/workflow_test.py
@@ -71,6 +71,37 @@ def test_start_workflow(workflow_config, workflow_client, boto_client):
     assert actual_run_id == boto_return['runId']
 
 
+def test_start_workflow_with_custom_execution_timeout(workflow_config, workflow_client, boto_client):
+    boto_return = mock.MagicMock()
+    boto_client.start_workflow_execution.return_value = boto_return
+    workflow_name = 'test'
+    version = '0.1'
+    execution_timeout = 123
+    workflow_client.start_workflow(
+        input='meow',
+        id='cat',
+        workflow_name=workflow_name,
+        version=version,
+        workflow_start_to_close_timeout=execution_timeout,
+    )
+
+    boto_client.start_workflow_execution.assert_called_once_with(
+        domain=workflow_config.domain,
+        childPolicy='TERMINATE',
+        workflowId='cat',
+        input='meow',
+        workflowType={
+            'name': workflow_name,
+            'version': version,
+        },
+        taskList={
+            'name': workflow_config.task_list,
+        },
+        executionStartToCloseTimeout=str(execution_timeout),
+        taskStartToCloseTimeout=str(workflow_config.task_start_to_close_timeout),
+    )
+
+
 def test_terminate_workflow(workflow_config, workflow_client, boto_client):
     workflow_client.terminate_workflow(
         'workflow_id',


### PR DESCRIPTION
allow specifying workflow_start_to_close timeout in start_workflow.
Allow setting task_start_to_close and task_schedule_to_close timeout in decider.