### PR TITLE
Support python 2.7, test against python 3.6 not 3.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage
 flake8
-ipython
+ipython < 6.0.0  # 6.0 drops support for py27
 mock
 pre-commit>=0.4.2
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, docs
+envlist = py27, py36, docs
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Addresses install-time errors from ipython 6.0.0 dropping py27 support

From a recent Jenkins run:
```
21:37:55   Using cached https://pypi.yelpcorp.com/p/ipython-6.2.1.tar.gz
21:37:55     Complete output from command python setup.py egg_info:
21:37:55     
21:37:55     IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
21:37:55     When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
21:37:55     Beginning with IPython 6.0, Python 3.3 and above is required.
21:37:55     
21:37:55     See IPython `README.rst` file for more information:
21:37:55     
21:37:55         https://github.com/ipython/ipython/blob/master/README.rst
21:37:55     
21:37:55     Python sys.version_info(major=2, minor=7, micro=6, releaselevel='final', serial=0) detected.
21:37:55     
21:37:55     
21:37:55     
21:37:55     ----------------------------------------
```